### PR TITLE
Add Hot Potato gamemode and Invite All Friends feature

### DIFF
--- a/AmongUsRevamped.cs
+++ b/AmongUsRevamped.cs
@@ -34,6 +34,7 @@ public partial class Main : BasePlugin
     public static ConfigEntry<bool> AutoStart { get; private set; }
     public static ConfigEntry<bool> DarkTheme { get; private set; }
     public static ConfigEntry<bool> LobbyMusic { get; private set; }
+    public static ConfigEntry<bool> InviteAllButton { get; private set; }
     public static ConfigEntry<bool> DisableInfoWhenDead { get; private set; }
     public static ConfigEntry<bool> DisableCommandHelper { get; private set; }
     public static ConfigEntry<bool> DisableCompatibilityWarning { get; private set; }
@@ -44,7 +45,7 @@ public partial class Main : BasePlugin
 
     public static bool HasArgumentException;
     public static string CredentialsText;
-    public const string ModVersion = "v1.8.4";
+    public const string ModVersion = "v1.8.5";
 
     public static float GameTimer;
 
@@ -92,6 +93,7 @@ public partial class Main : BasePlugin
         AutoStart = Config.Bind("Client Options", "Auto Start", false);
         DarkTheme = Config.Bind("Client Options", "Dark Theme", false);
         LobbyMusic = Config.Bind("Client Options", "Lobby Music", false);
+        InviteAllButton = Config.Bind("Client Options", "Invite All Friends Button", true);
         DisableInfoWhenDead = Config.Bind("Client Options", "Disable Task/Kill View", false);
         DisableCommandHelper = Config.Bind("Client Options", "Disable Command Helper", false);
         DisableCompatibilityWarning = Config.Bind("Client Options", "Disable Compatibility Warning", false);

--- a/AmongUsRevamped.csproj
+++ b/AmongUsRevamped.csproj
@@ -5,7 +5,7 @@
         <LangVersion>latest</LangVersion>
         <DebugType>embedded</DebugType>
         <Description>The ultimate Host-Only mod without Modded Protocol</Description>
-        <Authors>apemv</Authors>
+        <Authors>apemv, abusalehtusar</Authors>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <Configurations>Release;Android</Configurations>
         <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>

--- a/Modules/BatchedMessage.cs
+++ b/Modules/BatchedMessage.cs
@@ -1,0 +1,95 @@
+using AmongUs.GameOptions;
+using AmongUs.InnerNet.GameDataMessages;
+using Hazel;
+using InnerNet;
+
+namespace AmongUsRevamped;
+
+public class BatchedMessage
+{
+    private readonly MessageWriter writer;
+    private readonly int targetClientId;
+
+    public BatchedMessage(int targetClientId = -1)
+    {
+        writer = MessageWriter.Get(SendOption.Reliable);
+        this.targetClientId = targetClientId;
+
+        if (targetClientId == -1)
+        {
+            writer.StartMessage(Tags.GameData);
+            writer.Write(AmongUsClient.Instance.GameId);
+        }
+        else
+        {
+            writer.StartMessage(Tags.GameDataTo);
+            writer.Write(AmongUsClient.Instance.GameId);
+            writer.WritePacked(targetClientId);
+        }
+    }
+
+    private bool AmTarget => targetClientId == -1 || targetClientId == AmongUsClient.Instance.ClientId;
+
+    public void QueueSetColor(PlayerControl source, byte color)
+    {
+        if (source == null || source.Data == null) return;
+
+        if (AmTarget) source.SetColor(color);
+
+        writer.StartMessage((byte)GameDataTypes.RpcFlag);
+        writer.WritePacked(source.NetId);
+        writer.Write((byte)RpcCalls.SetColor);
+        writer.Write(source.Data.NetId);
+        writer.Write(color);
+        writer.EndMessage();
+    }
+
+    public void QueueSetRole(PlayerControl source, RoleTypes role, bool canOverride = false)
+    {
+        if (source == null) return;
+
+        if (AmTarget) source.StartCoroutine(source.CoSetRole(role, canOverride));
+
+        writer.StartMessage((byte)GameDataTypes.RpcFlag);
+        writer.WritePacked(source.NetId);
+        writer.Write((byte)RpcCalls.SetRole);
+        writer.Write((ushort)role);
+        writer.Write(canOverride);
+        writer.EndMessage();
+    }
+
+    public void QueueMurderPlayer(PlayerControl source, PlayerControl target, MurderResultFlags result)
+    {
+        if (source == null || target == null) return;
+
+        if (AmTarget) source.MurderPlayer(target, result);
+
+        writer.StartMessage((byte)GameDataTypes.RpcFlag);
+        writer.WritePacked(source.NetId);
+        writer.Write((byte)RpcCalls.MurderPlayer);
+        writer.WritePacked(target.NetId);
+        writer.Write((int)result);
+        writer.EndMessage();
+    }
+
+    public void QueueSetPetStr(PlayerControl source, string pet, byte seqId)
+    {
+        if (source == null || source.Data == null) return;
+
+        if (AmTarget) source.SetPet(pet, source.Data.DefaultOutfit.ColorId);
+
+        writer.StartMessage((byte)GameDataTypes.RpcFlag);
+        writer.WritePacked(source.NetId);
+        writer.Write((byte)RpcCalls.SetPetStr);
+        writer.Write(pet);
+        writer.Write(seqId);
+        writer.EndMessage();
+    }
+
+    public void FinishBatch()
+    {
+        writer.EndMessage();
+        AmongUsClient.Instance.SendOrDisconnect(writer);
+        writer.Recycle();
+    }
+}

--- a/Modules/CommandHelper.cs
+++ b/Modules/CommandHelper.cs
@@ -33,6 +33,9 @@ internal static class CommandHelper
         new Cmd { Name = new[] { "/sr" }, Prompt = "/sr", Description = Translator.Get("SrDesc"), HasVariable = false },
         new Cmd { Name = new[] { "/speedrun" }, Prompt = "/speedrun", Description = Translator.Get("SrDesc"), HasVariable = false },
 
+        new Cmd { Name = new[] { "/hp" }, Prompt = "/hp", Description = Translator.Get("hpDesc"), HasVariable = false },
+        new Cmd { Name = new[] { "/hotpotato" }, Prompt = "/hotpotato", Description = Translator.Get("hpDesc"), HasVariable = false },
+
         new Cmd { Name = new[] { "/eg" }, Prompt = "/eg", Description = Translator.Get("egDesc"), HasVariable = false },
         new Cmd { Name = new[] { "/endgame" }, Prompt = "/endgame", Description = Translator.Get("egDesc"), HasVariable = false },
 

--- a/Modules/CustomOptionsHolder.cs
+++ b/Modules/CustomOptionsHolder.cs
@@ -48,7 +48,19 @@ namespace AmongUsRevamped
 
         public static readonly string[] gameModes =
         {
-            "Standard", "0 Kill Cooldown", "Shift And Seek", "Speedrun"
+            "Standard", "0 Kill Cooldown", "Shift And Seek", "Speedrun", "Hot Potato"
+        };
+
+        // Index matches the in-game color id
+        public static readonly string[] playerColors =
+        {
+            "Red", "Blue", "Green", "Pink", "Orange", "Yellow", "Black", "White",
+            "Purple", "Brown", "Cyan", "Lime", "Maroon", "Rose", "Banana", "Gray", "Tan", "Coral"
+        };
+
+        public static readonly string[] potatoBurnTargets =
+        {
+            "Nearest", "Random"
         };
 
         public static readonly string[] accessLevels =
@@ -290,6 +302,15 @@ namespace AmongUsRevamped
         public static OptionItem GameAutoEndsAfter;
         public static OptionItem EngineerMode;
 
+        public static OptionItem TabGroupHotPotato;
+        public static OptionItem PotatoTimer;
+        public static OptionItem PotatoPassRadius;
+        public static OptionItem PotatoPassCooldown;
+        public static OptionItem PotatoSpawnClearRadius;
+        public static OptionItem PotatoHolderColor;
+        public static OptionItem SafePlayerColor;
+        public static OptionItem PotatoBurnPassTarget;
+
         // Abilities
         public static OptionItem TabGroupCrewmate;
 
@@ -516,6 +537,18 @@ namespace AmongUsRevamped
             GameAutoEndsAfter = IntegerOptionItem.Create(70077, Translator.Get("gameAutoEndsAfter"), new(0, 600, 10), 300, TabGroup.GamemodeSettings, false)
                 .SetValueFormat(OptionFormat.Seconds);
             EngineerMode = BooleanOptionItem.Create(70078, Translator.Get("engineerMode"), false, TabGroup.GamemodeSettings, false);
+
+            TabGroupHotPotato = TextOptionItem.Create(70100, Translator.Get("tabGroupHotPotato"), TabGroup.GamemodeSettings)
+                .SetColor(CL.Hex("#ff8c00"));
+            PotatoTimer = FloatOptionItem.Create(70101, Translator.Get("potatoTimer"), new(5f, 60f, 1f), 20f, TabGroup.GamemodeSettings, false)
+                .SetValueFormat(OptionFormat.Seconds);
+            PotatoPassRadius = FloatOptionItem.Create(70102, Translator.Get("potatoPassRadius"), new(0.5f, 5f, 0.1f), 1.2f, TabGroup.GamemodeSettings, false);
+            PotatoPassCooldown = FloatOptionItem.Create(70103, Translator.Get("potatoPassCooldown"), new(0f, 10f, 0.5f), 2f, TabGroup.GamemodeSettings, false)
+                .SetValueFormat(OptionFormat.Seconds);
+            PotatoSpawnClearRadius = FloatOptionItem.Create(70104, Translator.Get("potatoSpawnClearRadius"), new(0f, 30f, 1f), 8f, TabGroup.GamemodeSettings, false);
+            PotatoHolderColor = StringOptionItem.Create(70105, Translator.Get("potatoHolderColor"), playerColors, 6, TabGroup.GamemodeSettings, false);
+            SafePlayerColor = StringOptionItem.Create(70106, Translator.Get("safePlayerColor"), playerColors, 1, TabGroup.GamemodeSettings, false);
+            PotatoBurnPassTarget = StringOptionItem.Create(70107, Translator.Get("potatoBurnPassTarget"), potatoBurnTargets, 0, TabGroup.GamemodeSettings, false);
 
             // Gameplay Settings
             TabGroupSabotages = TextOptionItem.Create(60450, Translator.Get("tabGroupSabotages"), TabGroup.ModSettings)

--- a/Modules/FixedUpdate.cs
+++ b/Modules/FixedUpdate.cs
@@ -16,6 +16,8 @@ public static class FixedUpdate
             Main.GameTimer += Time.fixedDeltaTime;
         }
 
+        HotPotato.Update(Time.fixedDeltaTime);
+
         GameObject n = GameObject.Find("NewRequestInactive");
         if (n != null)
         {

--- a/Modules/HotPotato.cs
+++ b/Modules/HotPotato.cs
@@ -1,0 +1,400 @@
+using AmongUs.GameOptions;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using System;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace AmongUsRevamped;
+
+public static class HotPotato
+{
+    public const int GamemodeId = 4;
+    private static byte PotatoColor => (byte)Options.PotatoHolderColor.GetValue();
+    private static byte SafeColor => (byte)Options.SafePlayerColor.GetValue();
+    private const int DesiredTicks = 10;
+    private static int timerTicks = DesiredTicks;
+    public static byte HolderId = byte.MaxValue;
+    public static bool RoundActive;
+
+    // Set while we hand the host their countdown tasks so RpcSetTasksPatch leaves them alone
+    public static bool AssigningTimerTasks;
+
+    private static float tickTimer;
+    private static int ticksDone;
+    private static float passLock;
+    private static float announceLock;
+
+    public static bool IsActive => Options.Gamemode.GetValue() == GamemodeId && !Utils.isHideNSeek;
+
+    public static PlayerControl Holder
+    {
+        get
+        {
+            if (HolderId == byte.MaxValue) return null;
+
+            foreach (PlayerControl pc in Utils.AllAlivePlayerControls)
+            {
+                if (pc.PlayerId == HolderId) return pc;
+            }
+
+            return null;
+        }
+    }
+
+    public static void Reset()
+    {
+        HolderId = byte.MaxValue;
+        RoundActive = false;
+        AssigningTimerTasks = false;
+        tickTimer = 0f;
+        ticksDone = 0;
+        passLock = 0f;
+        announceLock = 0f;
+    }
+
+    // Overlong chat messages get the sender banned, so everything we send is clamped first
+    private const int MaxChatLength = 100;
+
+    private static string Clamp(string message)
+    {
+        return message.Length <= MaxChatLength ? message : message[..MaxChatLength];
+    }
+
+    // Messages with more than five digits get censored by the server; ConvertNum swaps them
+    // for circled digits when that threshold is crossed
+    private static void Announce(string message, float cooldown = 1.5f)
+    {
+        if (announceLock > 0f) return;
+
+        announceLock = cooldown;
+        PlayerControl.LocalPlayer.RpcSendChat(Clamp(SendChatPatch.ConvertNum(message)));
+    }
+
+    public static void Begin()
+    {
+        if (!AmongUsClient.Instance.AmHost || !IsActive) return;
+
+        try
+        {
+            Reset();
+
+            PlayerControl[] alive = Utils.AllAlivePlayerControls;
+            Logger.Info($" starting with {alive.Length} alive, ship={(ShipStatus.Instance != null)}", "HotPotato");
+
+            if (alive.Length < 1) return;
+
+            PlayerControl first = alive[Random.Range(0, alive.Length)];
+
+            RoundActive = true;
+
+            Scatter(first);
+            ClearOtherTaskLists();
+            GiveTo(first, announce: false, newPotato: true);
+
+            Announce($"Hot Potato! {first.Data.PlayerName} has the potato.\nTouch someone to pass it.", 3f);
+        }
+        catch (Exception e)
+        {
+            Logger.Error(e.ToString(), "HotPotato.Begin");
+        }
+    }
+
+    // Scatters everyone except the holder, who is left standing alone at the spawn room with
+    // the potato. Vents near spawn are skipped so nobody lands back on top of them.
+    private static void Scatter(PlayerControl holder)
+    {
+        if (ShipStatus.Instance == null) return;
+
+        var vents = ShipStatus.Instance.AllVents;
+        if (vents == null || vents.Length == 0) return;
+
+        // Measured from the map's own spawn point rather than a hardcoded room, so this still
+        // does the right thing on maps that do not start players in Cafeteria
+        Vector2 spawn = ShipStatus.Instance.InitialSpawnCenter;
+        float clearRadius = Options.PotatoSpawnClearRadius.GetFloat();
+
+        List<Vent> usable = [];
+
+        foreach (Vent vent in vents)
+        {
+            if (Vector2.Distance(spawn, vent.transform.position) < clearRadius) continue;
+
+            usable.Add(vent);
+        }
+
+        // A tight map, or too generous a radius, can rule out everything; better to scatter
+        // into the spawn room than not to scatter at all
+        if (usable.Count == 0)
+        {
+            foreach (Vent vent in vents) usable.Add(vent);
+        }
+
+        foreach (PlayerControl pc in Utils.AllAlivePlayerControls)
+        {
+            if (pc.PlayerId == holder.PlayerId || pc.MyPhysics == null) continue;
+
+            pc.MyPhysics.RpcBootFromVent(usable[Random.Range(0, usable.Count)].Id);
+        }
+    }
+
+    private static void ClearOtherTaskLists()
+    {
+        if (ShipStatus.Instance == null) return;
+
+        AssigningTimerTasks = true;
+
+        try
+        {
+            foreach (PlayerControl pc in PlayerControl.AllPlayerControls)
+            {
+                if (pc == null || pc.Data == null || pc == PlayerControl.LocalPlayer) continue;
+
+                pc.Data.RpcSetTasks(new Il2CppStructArray<byte>(0));
+            }
+        }
+        finally
+        {
+            AssigningTimerTasks = false;
+        }
+    }
+
+    private static void GiveTo(PlayerControl holder, bool announce = true, bool newPotato = false)
+    {
+        if (holder == null || holder.Data == null) return;
+
+        HolderId = holder.PlayerId;
+        passLock = Options.PotatoPassCooldown.GetFloat();
+
+        BatchedMessage batch = new();
+
+        foreach (PlayerControl pc in Utils.AllAlivePlayerControls)
+        {
+            batch.QueueSetColor(pc, pc.PlayerId == HolderId ? PotatoColor : SafeColor);
+        }
+
+        batch.FinishBatch();
+
+        if (newPotato) ResetTimerBar();
+
+        if (announce) Announce($"{holder.Data.PlayerName} has the potato!");
+    }
+
+    // Hands the host a fresh task list, which is what empties the shared bar
+    private static void ResetTimerBar()
+    {
+        tickTimer = 0f;
+        ticksDone = 0;
+
+        if (ShipStatus.Instance == null) return;
+
+        AssigningTimerTasks = true;
+
+        try
+        {
+            PlayerControl.LocalPlayer.Data.RpcSetTasks(BuildTimerTasks());
+        }
+        finally
+        {
+            AssigningTimerTasks = false;
+        }
+
+    }
+
+    // Built through the game's own task picker rather than by guessing ids. It skips task types
+    // it has already used, so a map with few short tasks yields a coarser countdown.
+    private static Il2CppStructArray<byte> BuildTimerTasks()
+    {
+        Il2CppSystem.Collections.Generic.List<byte> ids = new();
+        Il2CppSystem.Collections.Generic.HashSet<TaskTypes> usedTypes = new();
+        Il2CppSystem.Collections.Generic.List<NormalPlayerTask> pool = new();
+
+        foreach (NormalPlayerTask task in ShipStatus.Instance.ShortTasks) pool.Add(task);
+
+        int start = 0;
+        ShipStatus.Instance.AddTasksFromList(ref start, DesiredTicks, ids, usedTypes, pool);
+
+        timerTicks = Math.Max(1, ids.Count);
+
+        Il2CppStructArray<byte> result = new(ids.Count);
+        for (int i = 0; i < ids.Count; i++) result[i] = ids[i];
+
+        return result;
+    }
+
+    public static void Update(float deltaTime)
+    {
+        if (!AmongUsClient.Instance.AmHost || !IsActive || !RoundActive) return;
+        if (!Utils.InGame || Utils.IsMeeting || ExileController.Instance) return;
+
+        if (announceLock > 0f) announceLock -= deltaTime;
+        if (passLock > 0f) passLock -= deltaTime;
+
+        PlayerControl holder = Holder;
+
+        // Holder left or died some other way; hand the potato to whoever is left
+        if (holder == null)
+        {
+            PlayerControl[] alive = Utils.AllAlivePlayerControls;
+            if (alive.Length > 0) GiveTo(alive[Random.Range(0, alive.Length)], newPotato: true);
+            return;
+        }
+
+        if (CheckWin()) return;
+
+        TickTimer(holder, deltaTime);
+        CheckProximity(holder);
+    }
+
+    private static void TickTimer(PlayerControl holder, float deltaTime)
+    {
+        float interval = Options.PotatoTimer.GetFloat() / timerTicks;
+
+        tickTimer += deltaTime;
+        if (tickTimer < interval) return;
+
+        tickTimer = 0f;
+
+        if (ticksDone < timerTicks)
+        {
+            PlayerControl.LocalPlayer.RpcCompleteTask((uint)ticksDone);
+            ticksDone++;
+
+            // Read one tick after the reset rather than straight after it, so the game has had
+            // a chance to recompute the shared counters instead of reporting stale ones
+            if (ticksDone == 1 && GameData.Instance != null)
+            {
+                Logger.Info($" bar at first tick: {GameData.Instance.CompletedTasks}/{GameData.Instance.TotalTasks}, ticks={timerTicks}", "HotPotato");
+            }
+
+            return;
+        }
+
+        Burn(holder);
+    }
+
+    private static void Burn(PlayerControl holder)
+    {
+        string name = holder.Data.PlayerName;
+
+        holder.RpcSetRole(RoleTypes.CrewmateGhost, false);
+        Logger.Info($" {name} was burned by the potato", "HotPotato");
+
+        PlayerControl next = Options.PotatoBurnPassTarget.GetValue() == 1
+            ? RandomAlive(holder)
+            : NearestTo(holder, ignore: holder);
+
+        if (next == null)
+        {
+            CheckWin();
+            return;
+        }
+
+        Announce($"{name} got burned!\n{next.Data.PlayerName} has the potato.", 3f);
+        GiveTo(next, announce: false, newPotato: true);
+    }
+
+    private static void CheckProximity(PlayerControl holder)
+    {
+        if (passLock > 0f) return;
+
+        float radius = Options.PotatoPassRadius.GetFloat();
+
+        PlayerControl target = NearestTo(holder, ignore: holder, maxDistance: radius);
+
+        if (target == null) return;
+
+        GiveTo(target);
+    }
+
+    private static PlayerControl NearestTo(PlayerControl origin, PlayerControl ignore, float maxDistance = float.MaxValue)
+    {
+        Vector2 from = origin.GetTruePosition();
+        PlayerControl best = null;
+        float bestDistance = maxDistance;
+
+        foreach (PlayerControl pc in Utils.AllAlivePlayerControls)
+        {
+            if (pc == ignore || pc.PlayerId == origin.PlayerId) continue;
+
+            float distance = Vector2.Distance(from, pc.GetTruePosition());
+            if (distance > bestDistance) continue;
+
+            bestDistance = distance;
+            best = pc;
+        }
+
+        return best;
+    }
+
+    private static PlayerControl RandomAlive(PlayerControl ignore)
+    {
+        List<PlayerControl> pool = [];
+
+        foreach (PlayerControl pc in Utils.AllAlivePlayerControls)
+        {
+            if (pc == ignore || pc.PlayerId == ignore.PlayerId) continue;
+
+            pool.Add(pc);
+        }
+
+        return pool.Count == 0 ? null : pool[Random.Range(0, pool.Count)];
+    }
+
+    private static bool CheckWin()
+    {
+        if (Options.NoGameEnd.GetBool()) return false;
+
+        PlayerControl[] alive = Utils.AllAlivePlayerControls;
+        if (alive.Length > 1) return false;
+
+        RoundActive = false;
+
+        if (alive.Length == 1)
+        {
+            Utils.CustomWinnerEndGame(alive[0], 1);
+            NormalGameEndChecker.LastWinReason = $"{alive[0].Data.PlayerName} wins! (Survived the potato)";
+        }
+        else
+        {
+            Utils.CustomWinnerEndGame(PlayerControl.LocalPlayer, 0);
+            NormalGameEndChecker.LastWinReason = "Nobody survived the potato";
+        }
+
+        NormalGameEndChecker.canUpdateWinnerText = false;
+        return true;
+    }
+
+
+    private static string[] Rules()
+    {
+        string color = Options.playerColors[Options.PotatoHolderColor.GetValue()];
+
+        return
+        [
+            $"Hot Potato: \n{color} holds the potato, avoid {color}.\n{color} can pass the potato by touching someone.",
+            $"Potato burns the holder after {Options.PotatoTimer.GetFloat():0.#}s. Last one standing wins.",
+            "The task bar is the timer - watch it fill.",
+        ];
+    }
+
+    // Roughly matches the pacing Utils.ChatCommand uses between its two messages
+    private const float RuleSpacing = 2.2f;
+
+    public static void SendRules()
+    {
+        if (OnGameJoinedPatch.WaitingForChat) return;
+
+        OnGameJoinedPatch.WaitingForChat = true;
+
+        string[] rules = Rules();
+
+        for (int i = 0; i < rules.Length; i++)
+        {
+            string line = Clamp(SendChatPatch.ConvertNum(rules[i]));
+
+            new LateTask(() => PlayerControl.LocalPlayer.RpcSendChat(line), RuleSpacing * i, $"HotPotatoRules{i}", false);
+        }
+
+        new LateTask(() => OnGameJoinedPatch.WaitingForChat = false, RuleSpacing * rules.Length, "HotPotatoRulesEnd", false);
+    }
+}

--- a/Modules/Hotkeys.cs
+++ b/Modules/Hotkeys.cs
@@ -23,6 +23,12 @@ internal class Hotkeys
             PlayerControl.LocalPlayer.Collider.enabled = !Ctrl;
         }
         
+        if (Input.GetKeyDown(KeyCode.I) && Shift && !HudManager.Instance.Chat.IsOpenOrOpening)
+        {
+            if (InviteAllFriends.Ready) InviteAllFriends.SendAll();
+            else if (InviteAllFriends.Available) Logger.SendInGame(Translator.Get("inviteAllCooldown", Mathf.CeilToInt(InviteAllFriends.RemainingCooldown)));
+        }
+
         if (!AmongUsClient.Instance.AmHost) return;
 
         if (Input.GetKey(KeyCode.L) && Shift && Enter)

--- a/Modules/InviteAllFriends.cs
+++ b/Modules/InviteAllFriends.cs
@@ -1,0 +1,258 @@
+using System;
+using Assets.InnerNet;
+using Il2CppInterop.Runtime;
+using InnerNet;
+using UnityEngine;
+
+namespace AmongUsRevamped;
+
+public static class InviteAllFriends
+{
+    // Invites go out one at a time and the next one is only scheduled once the server has answered
+    // the previous, so the pace follows whatever the endpoint actually tolerates.
+    private const float MinInterval = 0.4f;
+    private const float MaxInterval = 5f;
+    private const float ResponseTimeout = 8f;
+    private const int MaxRetries = 2;
+    private const float Cooldown = 20f;
+
+    // The invite endpoint answers 429 when we are going too fast
+    private const int RateLimitedCode = 429;
+
+    private static float lastUsed = -Cooldown;
+    private static bool sending;
+
+    private static readonly List<Target> Queue = [];
+    private static int queueIndex;
+    private static int retries;
+    private static float interval = MinInterval;
+    private static int waitToken;
+    private static bool awaitingResponse;
+
+    private static int succeeded;
+    private static int failed;
+    private static int rateLimitHits;
+
+    private readonly struct Target(string puid, string friendCode)
+    {
+        public readonly string Puid = puid;
+        public readonly string FriendCode = friendCode;
+    }
+
+    public static bool Available =>
+        AmongUsClient.Instance != null &&
+        FriendsListManager.InstanceExists &&
+        Utils.IsLobby && Utils.IsOnlineGame &&
+        !IsGuestAccount();
+
+    public static bool Ready => Available && !sending && Time.realtimeSinceStartup - lastUsed >= Cooldown;
+
+    public static bool DebugIsLobby => AmongUsClient.Instance != null && Utils.IsLobby;
+    public static bool DebugIsOnline => AmongUsClient.Instance != null && Utils.IsOnlineGame;
+    public static bool DebugIsGuest => IsGuestAccount();
+
+    public static float RemainingCooldown => Mathf.Max(0f, Cooldown - (Time.realtimeSinceStartup - lastUsed));
+
+    private static bool IsGuestAccount()
+    {
+        // Guest accounts have no friends list, EOSManager reports them as not logged in
+        return EOSManager.InstanceExists && !EOSManager.Instance.HasFinishedLoginFlow();
+    }
+
+    public static void SendAll()
+    {
+        if (!Ready) return;
+
+        string roomCode = GameCode.IntToGameName(AmongUsClient.Instance.GameId);
+        if (string.IsNullOrEmpty(roomCode))
+        {
+            Logger.SendInGame(Translator.Get("inviteAllNoLobby"));
+            return;
+        }
+
+        FriendsListManager manager = FriendsListManager.Instance;
+
+        sending = true;
+        lastUsed = Time.realtimeSinceStartup;
+
+        // The list is only filled once the friends panel has been opened, so refresh it first
+        manager.StartCoroutine(manager.RefreshFriendsList((Il2CppSystem.Action)(() => BuildQueue(manager, roomCode)), false));
+    }
+
+    private static void BuildQueue(FriendsListManager manager, string roomCode)
+    {
+        try
+        {
+            var friends = manager.Friends;
+
+            if (friends == null || friends.Count == 0)
+            {
+                Abort();
+                lastUsed = -Cooldown;
+                Logger.SendInGame(Translator.Get("inviteAllNoFriends"));
+                return;
+            }
+
+            Queue.Clear();
+            queueIndex = 0;
+            retries = 0;
+            interval = MinInterval;
+            succeeded = failed = rateLimitHits = 0;
+            awaitingResponse = false;
+
+            foreach (ResponseFriends friend in friends)
+            {
+                if (friend == null || string.IsNullOrEmpty(friend.FriendPuid)) continue;
+                if (manager.IsPlayerBlocked(friend.FriendPuid) || manager.HasPlayerBlockedMe(friend.FriendPuid)) continue;
+
+                Queue.Add(new Target(friend.FriendPuid, friend.FriendCode));
+            }
+
+            if (Queue.Count == 0)
+            {
+                Abort();
+                lastUsed = -Cooldown;
+                Logger.SendInGame(Translator.Get("inviteAllNoFriends"));
+                return;
+            }
+
+            Logger.Info($"Sending {Queue.Count} lobby invites for {roomCode}", "InviteAllFriends");
+            Logger.SendInGame(Translator.Get("inviteAllSending", Queue.Count));
+
+            SendNext(manager, roomCode);
+        }
+        catch (Exception ex)
+        {
+            Abort();
+            Logger.Exception(ex, "InviteAllFriends");
+        }
+    }
+
+    private static void SendNext(FriendsListManager manager, string roomCode)
+    {
+        if (queueIndex >= Queue.Count)
+        {
+            Finish();
+            return;
+        }
+
+        // A lobby switch or disconnect mid-batch makes the remaining invites point at a dead room
+        if (!Available || GameCode.IntToGameName(AmongUsClient.Instance.GameId) != roomCode)
+        {
+            Logger.Warn($"Stopped after {succeeded + failed}/{Queue.Count} invites, no longer in lobby {roomCode}", "InviteAllFriends");
+            Finish();
+            return;
+        }
+
+        Target target = Queue[queueIndex];
+        int token = ++waitToken;
+        awaitingResponse = true;
+
+        manager.SendGameInvite(target.Puid, roomCode,
+            DelegateSupport.ConvertDelegate<Il2CppSystem.Action<ResponseState, Response<ResponseFriendsListRequest>>>(
+                new Action<ResponseState, Response<ResponseFriendsListRequest>>((state, response) =>
+                    OnResponse(manager, roomCode, target, token, state, response))));
+
+        // The callback is not guaranteed to fire, so never let the batch stall on it
+        new LateTask(() =>
+        {
+            if (token != waitToken || !awaitingResponse) return;
+
+            failed++;
+            Logger.Warn($"Invite to {target.FriendCode} timed out after {ResponseTimeout}s", "InviteAllFriends");
+            Advance(manager, roomCode, token, false);
+        }, ResponseTimeout, "", false);
+    }
+
+    private static void OnResponse(FriendsListManager manager, string roomCode, Target target, int token,
+        ResponseState state, Response<ResponseFriendsListRequest> response)
+    {
+        if (token != waitToken || !awaitingResponse) return;
+
+        if (state == ResponseState.Success)
+        {
+            succeeded++;
+            // Back off gradually once the server is keeping up again
+            interval = Mathf.Max(MinInterval, interval * 0.8f);
+            Advance(manager, roomCode, token, false);
+            return;
+        }
+
+        bool rateLimited = IsRateLimited(response, out int code, out string title);
+
+        if (rateLimited)
+        {
+            rateLimitHits++;
+            interval = Mathf.Min(MaxInterval, Mathf.Max(interval * 2f, MinInterval * 2f));
+            Logger.Warn($"Rate limited on {target.FriendCode} (code {code}), interval now {interval:0.00}s", "InviteAllFriends");
+
+            if (retries < MaxRetries)
+            {
+                retries++;
+                Advance(manager, roomCode, token, true);
+                return;
+            }
+        }
+        else
+        {
+            Logger.Warn($"Invite to {target.FriendCode} failed ({state}, code {code}{(string.IsNullOrEmpty(title) ? "" : $", {title}")})", "InviteAllFriends");
+        }
+
+        failed++;
+        Advance(manager, roomCode, token, false);
+    }
+
+    private static bool IsRateLimited(Response<ResponseFriendsListRequest> response, out int code, out string title)
+    {
+        code = 0;
+        title = null;
+
+        var errors = response?.Errors;
+        if (errors == null) return false;
+
+        for (int i = 0; i < errors.Length; i++)
+        {
+            ResponseError error = errors[i];
+            if (error == null) continue;
+
+            code = error.Code;
+            title = error.Title;
+
+            if (error.Code == RateLimitedCode || error.Detail == RateLimitedCode) return true;
+        }
+
+        return false;
+    }
+
+    private static void Advance(FriendsListManager manager, string roomCode, int token, bool retrySameTarget)
+    {
+        if (token != waitToken) return;
+
+        awaitingResponse = false;
+        if (!retrySameTarget)
+        {
+            queueIndex++;
+            retries = 0;
+        }
+
+        new LateTask(() => SendNext(manager, roomCode), interval, "", false);
+    }
+
+    private static void Finish()
+    {
+        sending = false;
+        awaitingResponse = false;
+        waitToken++;
+
+        Logger.Info($"Invite results: {succeeded} ok, {failed} failed, {rateLimitHits} rate limited, final interval {interval:0.00}s", "InviteAllFriends");
+        Logger.SendInGame(Translator.Get("inviteAllResult", succeeded, Queue.Count));
+    }
+
+    private static void Abort()
+    {
+        sending = false;
+        awaitingResponse = false;
+        waitToken++;
+        Queue.Clear();
+    }
+}

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -201,6 +201,7 @@ public static class Utils
     public static void ClearLeftoverData()
     {
         RpcSetTasksPatch.GlobalTaskIds = null;
+        HotPotato.Reset();
         HandlingGameEnd = false;
         OnGameJoinedPatch.AutoStartCheck = false;
         Main.GameTimer = 0f;

--- a/Patches/ChatPatches.cs
+++ b/Patches/ChatPatches.cs
@@ -390,6 +390,16 @@ internal static class SendChatPatch
             return false;
         }
 
+        if (text == "/hp" || text == "/hotpotato")
+        {
+            // SendRules does not touch the input field the way Utils.ChatCommand does
+            __instance.freeChatField.textArea.Clear();
+            __instance.freeChatField.textArea.SetText(string.Empty);
+
+            HotPotato.SendRules();
+            return false;
+        }
+
         if (text == "/r" || text == "/roles")
         {
             switch (Options.Gamemode.GetValue())
@@ -415,6 +425,10 @@ internal static class SendChatPatch
 
                 case 3:
                 Utils.ChatCommand(__instance, $"Speedrun:\n\nEveryone is a crewmate. The 1st player to finish tasks wins the game. Game auto ends after {Options.GameAutoEndsAfter.GetInt()}s", "", false);
+                break;
+
+                case 4:
+                HotPotato.SendRules();
                 break;
 
             }
@@ -701,6 +715,12 @@ public static class RPCHandlerPatch
                     Utils.ModeratorChatCommand($"Speedrun:\n\nEveryone is a crewmate. The 1st player to finish tasks wins the game. Game auto ends after {Options.GameAutoEndsAfter.GetInt()}s", "", false);
                 }
 
+                if (text == "/hp" || text == "/hotpotato")
+                {
+                    if (Utils.CheckAccessLevel(__instance.Data.FriendCode) < Options.SlashRolesAndGamemodeCmd.GetValue()) return;
+                    HotPotato.SendRules();
+                }
+
                 if (text == "/r" || text == "/roles")
                 {
                     if (Utils.CheckAccessLevel(__instance.Data.FriendCode) < Options.SlashRolesAndGamemodeCmd.GetValue()) return;
@@ -727,6 +747,10 @@ public static class RPCHandlerPatch
 
                         case 3:
                         Utils.ModeratorChatCommand($"Speedrun:\n\nEveryone is a crewmate. The 1st player to finish tasks wins the game. Game auto ends after {Options.GameAutoEndsAfter.GetInt()}s", "", false);
+                        break;
+
+                        case 4:
+                        HotPotato.SendRules();
                         break;
 
                     }

--- a/Patches/ClientOptionsPatch.cs
+++ b/Patches/ClientOptionsPatch.cs
@@ -14,6 +14,7 @@ namespace AmongUsRevamped
         private static ClientOptionItem AutoStart;
         private static ClientOptionItem DarkTheme;
         private static ClientOptionItem LobbyMusic;
+        private static ClientOptionItem InviteAllButton;
         private static ClientOptionItem DisableInfoWhenDead;
         private static ClientOptionItem DisableCommandHelper;
         private static ClientOptionItem DisableCompatibilityWarning;
@@ -35,6 +36,9 @@ namespace AmongUsRevamped
 
             if (ShowFPS == null || ShowFPS.ToggleButton == null)
                 ShowFPS = ClientOptionItem.Create(Translator.Get("showFPS"), Main.ShowFps, __instance);
+
+            if (InviteAllButton == null || InviteAllButton.ToggleButton == null)
+                InviteAllButton = ClientOptionItem.Create(Translator.Get("inviteAllFriendsButton"), Main.InviteAllButton, __instance);
 
             if (DisableInfoWhenDead == null || DisableInfoWhenDead.ToggleButton == null)
                 DisableInfoWhenDead = ClientOptionItem.Create(Translator.Get("disableInfoWhenDead"), Main.DisableInfoWhenDead, __instance);

--- a/Patches/EndGamePatches.cs
+++ b/Patches/EndGamePatches.cs
@@ -29,7 +29,11 @@ class NormalGameEndChecker
     public static bool Prefix()
     {
 
-        if (Options.NoGameEnd.GetBool() || Options.Gamemode.GetValue() == 3 || Utils.HandlingGameEnd) return false;
+        // Hot Potato ends the game itself and must suppress the vanilla checks for the whole
+        // mode, not just while a round runs: everyone is a Crewmate, so between the match
+        // starting and the round beginning vanilla sees zero impostors and instantly awards the
+        // crew a win. HotPotato.Begin always starts a round, so nothing is left unendable.
+        if (Options.NoGameEnd.GetBool() || Options.Gamemode.GetValue() == 3 || HotPotato.IsActive || Utils.HandlingGameEnd) return false;
 
         var allPlayers = PlayerControl.AllPlayerControls.ToArray();
 

--- a/Patches/IntroPatch.cs
+++ b/Patches/IntroPatch.cs
@@ -34,6 +34,11 @@ internal static class CoShowIntroPatch
 
         if (!Utils.isHideNSeek && Options.Gamemode.GetValue() < 2) Logger.Info($" {AbilityManagement.RoleList()}", "AbilityInfo");
 
+        // Run while the intro cutscene is still covering the screen, so players are already
+        // scattered and recoloured by the time they can see the map. Waiting for OnGameStart
+        // meant doing all of it in the open, several seconds after the round had begun.
+        if (HotPotato.IsActive) new LateTask(HotPotato.Begin, 1f, "HotPotatoBegin");
+
         if (Options.DisableAnnoyingMeetingCalls.GetBool() && !Utils.isHideNSeek)
         {
             Utils.CanCallMeetings = false;

--- a/Patches/InviteAllFriendsPatch.cs
+++ b/Patches/InviteAllFriendsPatch.cs
@@ -1,0 +1,171 @@
+using TMPro;
+using UnityEngine;
+
+namespace AmongUsRevamped;
+
+[HarmonyPatch(typeof(FriendsListUI), nameof(FriendsListUI.Open))]
+public static class InviteAllFriendsButtonPatch
+{
+    public static PassiveButton inviteAllButton;
+    private static TextMeshPro inviteAllLabel;
+
+    public static void Postfix(FriendsListUI __instance) => Ensure(__instance);
+
+    public static void Ensure(FriendsListUI __instance)
+    {
+        if (__instance == null || inviteAllButton != null) return;
+
+        var template = __instance.ViewRequestsButton;
+        if (template == null)
+        {
+            Logger.Warn("No template button in the friends panel, invite all button not created", "InviteAllFriends");
+            return;
+        }
+
+        // The platform friends button occupies the slot right of the "Among Us Friends" pill and is
+        // hidden on platforms without a friends list, so borrow its transform to sit beside the pill
+        var slot = __instance.PlatformFriendsButton != null ? __instance.PlatformFriendsButton.transform : null;
+        var parent = slot != null ? slot.parent : template.transform.parent;
+
+        var clone = Object.Instantiate(template.gameObject, parent);
+        clone.name = "InviteAllFriendsButton";
+
+        if (slot != null)
+        {
+            clone.transform.localPosition = slot.localPosition;
+            clone.transform.localScale = slot.localScale;
+
+            if (__instance.PlatformFriendsButton.activeSelf)
+                clone.transform.localPosition += new Vector3(1.9f, 0f, 0f);
+
+            var slotRenderer = slot.GetComponent<SpriteRenderer>();
+            if (slotRenderer != null)
+            {
+                var renderers = clone.GetComponentsInChildren<SpriteRenderer>(true);
+                for (int i = 0; i < renderers.Length; i++)
+                {
+                    if (renderers[i] != null) renderers[i].size = slotRenderer.size;
+                }
+            }
+        }
+        else
+        {
+            clone.transform.localPosition = template.transform.localPosition + new Vector3(0f, -1.1f, -0.1f);
+            clone.transform.localScale = template.transform.localScale * 0.85f;
+        }
+
+        inviteAllButton = clone.GetComponent<PassiveButton>();
+        if (inviteAllButton == null)
+        {
+            Logger.Warn("Template button has no PassiveButton, invite all button not created", "InviteAllFriends");
+            Object.Destroy(clone);
+            return;
+        }
+
+        inviteAllButton.selected = false;
+        if (inviteAllButton.selectedSprites != null) inviteAllButton.selectedSprites.SetActive(false);
+        if (inviteAllButton.selectedInactiveSprites != null) inviteAllButton.selectedInactiveSprites.SetActive(false);
+        if (inviteAllButton.onClickSprites != null) inviteAllButton.onClickSprites.SetActive(false);
+        if (inviteAllButton.disabledSprites != null) inviteAllButton.disabledSprites.SetActive(false);
+
+        // The template's label is a sibling rather than a child, so the clone comes out blank
+        inviteAllLabel = clone.GetComponentInChildren<TextMeshPro>();
+        if (inviteAllLabel == null && __instance.ViewRequestsText != null)
+        {
+            inviteAllLabel = Object.Instantiate(__instance.ViewRequestsText, clone.transform);
+            inviteAllLabel.name = "InviteAllFriendsText";
+            inviteAllLabel.transform.localPosition = new Vector3(0f, 0f, -0.1f);
+            inviteAllLabel.transform.localScale = Vector3.one * 0.75f;
+            inviteAllLabel.alignment = TextAlignmentOptions.Center;
+        }
+
+        if (inviteAllLabel != null)
+        {
+            inviteAllLabel.DestroyTranslator();
+            inviteAllLabel.text = Translator.Get("inviteAllFriends");
+        }
+
+        inviteAllButton.OnClick = new();
+        inviteAllButton.OnClick.AddListener((UnityEngine.Events.UnityAction)(() =>
+        {
+            if (InviteAllFriends.Ready)
+            {
+                InviteAllFriends.SendAll();
+                return;
+            }
+
+            if (InviteAllFriends.Available)
+                Logger.SendInGame(Translator.Get("inviteAllCooldown", Mathf.CeilToInt(InviteAllFriends.RemainingCooldown)));
+            else
+                Logger.SendInGame(Translator.Get("inviteAllNoLobby"));
+        }));
+
+        clone.SetActive(false);
+
+        Logger.Info($"Created invite all button under {template.name} at {clone.transform.localPosition}", "InviteAllFriends");
+
+        // Real coordinates of the surrounding widgets, so the placement can be corrected without guessing
+        LogAnchor("ViewRequestsButton", __instance.ViewRequestsButton?.transform);
+        LogAnchor("AddFriendArea", __instance.AddFriendArea?.transform);
+        LogAnchor("InactiveAllFriends", __instance.InactiveAllFriends?.transform);
+        LogAnchor("PlatformFriendsButton", __instance.PlatformFriendsButton?.transform);
+        LogAnchor("FriendArea", __instance.FriendArea?.transform);
+    }
+
+    private static void LogAnchor(string label, Transform target)
+    {
+        if (target == null)
+        {
+            Logger.Info($"anchor {label}: null", "InviteAllFriends");
+            return;
+        }
+
+        var renderer = target.GetComponent<SpriteRenderer>();
+        string bounds = renderer != null ? $" size={renderer.size} bounds={renderer.bounds.size}" : "";
+        Logger.Info($"anchor {label}: local={target.localPosition} world={target.position} parent={target.parent?.name}{bounds}", "InviteAllFriends");
+    }
+}
+
+[HarmonyPatch(typeof(FriendsListUI), nameof(FriendsListUI.Update))]
+public static class InviteAllFriendsButtonUpdatePatch
+{
+    private static string lastState;
+
+    public static void Postfix(FriendsListUI __instance)
+    {
+        if (__instance == null) return;
+
+        InviteAllFriendsButtonPatch.Ensure(__instance);
+
+        var button = InviteAllFriendsButtonPatch.inviteAllButton;
+
+        bool optionOn = Main.InviteAllButton.Value;
+        bool open = __instance.IsOpen;
+        bool rightTab = __instance.CurrentTab == FriendsListUI.FriendsListTab.AmongUsFriends;
+        bool available = InviteAllFriends.Available;
+
+        string state = $"button={button != null} option={optionOn} open={open} tab={__instance.CurrentTab} available={available} " +
+                       $"(lobby={InviteAllFriends.DebugIsLobby} online={InviteAllFriends.DebugIsOnline} manager={FriendsListManager.InstanceExists} guest={InviteAllFriends.DebugIsGuest})";
+
+        if (state != lastState)
+        {
+            lastState = state;
+            Logger.Info(state, "InviteAllFriends");
+        }
+
+        if (button == null) return;
+
+        bool show = optionOn && open && rightTab && available;
+        if (button.gameObject.activeSelf != show) button.gameObject.SetActive(show);
+    }
+}
+
+[HarmonyPatch(typeof(FriendsListUI), nameof(FriendsListUI.OnDisable))]
+public static class InviteAllFriendsCleanupPatch
+{
+    public static void Postfix()
+    {
+        // The panel is rebuilt per scene, so drop the stale reference and let Open recreate it
+        InviteAllFriendsButtonPatch.inviteAllButton = null;
+    }
+}

--- a/Patches/OnGameStartedPatch.cs
+++ b/Patches/OnGameStartedPatch.cs
@@ -27,7 +27,9 @@ internal class CoStartGamePatch
 class PlayerControlSetRolePatch
 {
     public static bool FirstAssign;
+
     private static readonly HashSet<byte> ProcessedPlayers = new();
+
     public static HashSet<byte> Seekers = new();
     public static HashSet<PlayerControl> Jesters = new();
     private static readonly System.Random rand = new System.Random();
@@ -81,6 +83,8 @@ class PlayerControlSetRolePatch
             if (Options.EngineerMode.GetBool()) roleType = RoleTypes.Engineer;
             else roleType = RoleTypes.Crewmate;
         }
+
+        if (HotPotato.IsActive) roleType = RoleTypes.Crewmate;
 
         if (Options.Gamemode.GetValue() == 2 && !Utils.isHideNSeek)
         {

--- a/Patches/PlayerControlPatches.cs
+++ b/Patches/PlayerControlPatches.cs
@@ -25,6 +25,14 @@ class ReportDeadBodyPatch
 
         // target == null means meeting
 
+        // Hot Potato has nothing to discuss and a meeting would freeze the countdown, so both
+        // body reports and emergency meetings are refused outright
+        if (HotPotato.IsActive)
+        {
+            Logger.Info($" Blocked {__instance.Data.PlayerName} calling a meeting", "ReportDeadBodyPatch");
+            return false;
+        }
+
         if (Options.Gamemode.GetValue() == 2 || Options.Gamemode.GetValue() == 3)
         {
             if (target != null)
@@ -69,13 +77,20 @@ internal static class MurderPlayerPatch
             {
                 foreach (var p in PlayerControl.AllPlayerControls)
                 {
+                    if (p == null || p.Data == null) continue;
+
+                    string roleText = Utils.StoredRoleText.GetValueOrDefault(p.PlayerId, "");
+
                     if (p.Data.Role.IsImpostor)
                     {
-                        p.cosmetics.nameText.text = $"{p.Data.PlayerName}<color=red><size=90%>({killCount[p.Data.PlayerId]}†)</color> - {Utils.StoredRoleText[p.PlayerId]}";
+                        p.cosmetics.nameText.text = $"{p.Data.PlayerName}<color=red><size=90%>({killCount.GetValueOrDefault(p.Data.PlayerId, 0)}†)</color> - {roleText}";
                     }
                     else
                     {
-                        p.cosmetics.nameText.text = $"{p.Data.PlayerName}<color=green><size=90%>({PlayerControlCompleteTaskPatch.playerTasksCompleted[p.PlayerId]}/{PlayerControlCompleteTaskPatch.tasksPerPlayer[p.PlayerId]})</color> - {Utils.StoredRoleText[p.PlayerId]}";
+                        int done = PlayerControlCompleteTaskPatch.playerTasksCompleted.GetValueOrDefault(p.PlayerId, 0);
+                        int total = PlayerControlCompleteTaskPatch.tasksPerPlayer.GetValueOrDefault(p.PlayerId, 0);
+
+                        p.cosmetics.nameText.text = $"{p.Data.PlayerName}<color=green><size=90%>({done}/{total})</color> - {roleText}";
                     }
                 }
             }
@@ -220,6 +235,9 @@ class PlayerControlCompleteTaskPatch
     public static void CalculateTaskWin()
     {
         if (!Utils.GamePastRoleSelection || Utils.isHideNSeek || Options.NoGameEnd.GetBool() || !CoShowIntroPatch.IntroInitiated) return;
+
+        // Hot Potato repurposes the task bar as its countdown, so a full bar is not a crew win
+        if (HotPotato.IsActive) return;
 
         //Logger.Info($" Checking if {GameData.Instance.CompletedTasks} - {ignoredCompletedTasks} >= ({GameData.Instance.TotalTasks} - {ignoredTasks}) * 0.01 * {Options.TaskPercentNeededToWin.GetInt()}", "TaskPatch");
 

--- a/Patches/TaskAssignPatch.cs
+++ b/Patches/TaskAssignPatch.cs
@@ -125,6 +125,9 @@ internal static class RpcSetTasksPatch
     {
         if (!AmongUsClient.Instance.AmHost) return;
 
+        // Hot Potato drives the task bar as a countdown, so its task lists must pass through as-is
+        if (HotPotato.AssigningTimerTasks) return;
+
         PlayerControl pc = __instance.Object;
         if (pc == null) return;
 

--- a/Patches/VentPatches.cs
+++ b/Patches/VentPatches.cs
@@ -1,5 +1,20 @@
 ﻿namespace AmongUsRevamped;
 
+[HarmonyPatch(typeof(Vent), nameof(Vent.CanUse))]
+class HotPotatoVentPatch
+{
+    public static bool Prefix(ref bool canUse, ref bool couldUse, ref float __result)
+    {
+        if (!HotPotato.IsActive) return true;
+
+        canUse = false;
+        couldUse = false;
+        __result = float.MaxValue;
+
+        return false;
+    }
+}
+
 //Old Patch for Mayor
 
 /*

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - 0 Kill Cooldown
 - Shift and Seek
 - Speedrun
+- Hot Potato
 ## <b>❓ Other Improvements:</b>
 - Among Us Revamped supports other languages
 - Select a language in Language/YourLanguage.txt
@@ -103,6 +104,7 @@
 - Higher and more accurate Option ranges
 - Always visible lobby timer
 - Access experimental animation test scene
+- Invite all Steam friends to the lobby at once
 - <b>🎉 And this all works in public lobbies!</b>
 
 ### Hotkeys
@@ -115,6 +117,7 @@
 | `Shift`             | 5x Option increment                         | In Options Menu                    |
 | `Ctrl`              | Noclip in lobby                             | In Lobby                           |
 | `Ctrl`              | 10x Option increment                        | In Options Menu                    |
+| `Shift`+`I`         | Invite all Steam friends to the lobby       | In Lobby                           |
 
 ### Chat Commands
 | Command                                     | Function                                          |
@@ -123,7 +126,7 @@
 | /l<br>/lastgame                             | Send last game info                               |
 | /r                                          | Send current gamemode/roles description           |
 | /r {ability}                                | Send specific Ability info                        |
-| /0kc<br>/sns</br>/sp                        | Send respective gamemode description              |
+| /0kc<br>/sns</br>/sp<br>/hp                 | Send respective gamemode description              |
 | /ban {name}                                 | Ban a player by name                              |
 | /kick {name}                                | Kick a player by name                             |
 | /cban {color}                               | Ban a player by color                             |
@@ -155,6 +158,9 @@
 ### :star: [MoreGamemodes](https://github.com/Rabek009/MoreGamemodes)
 > - Some Chat Patches
 > - OptionItem System
+
+**Contributors:**
+- **abusalehtusar** — Hot Potato gamemode, Invite All Friends feature
 ---
 This project is licensed under the GNU General Public License version 3.0. For more details, please refer to the [LICENSE](https://github.com/apemv/AmongUsRevamped/blob/main/LICENSE) file.
 ---

--- a/Resources/Language/English.json
+++ b/Resources/Language/English.json
@@ -216,7 +216,7 @@
   "disableSubmitScan": "Disable Submit Scan",
   "disableUploadData": "Disable Upload Data",
 
-  "allCommandsFull": "<b>ALL COMMANDS:</b>\n\n<b>/help</b>\nShow this message.\n<b>/aur, /socials</b>\nSend Among Us Revamped social links.\n\n<b>/r, /gm</b>\nSend current mode description or ability list.\n<b>/r {ability}</b>\nSend specific ability info.\n<b>/l, /lastgame</b>\nSend last winner info.\n\n<b>/0kc, /0killcooldown</b>\nSend 0 Kill Cooldown mode description.\n<b>/sns, /shiftandseek</b>\nSend Shift and Seek mode description.\n<b>/sp, /speedrun</b>\nSend Speedrun mode description.\n\n/<b>kick, /ban</b>\nKick or ban a player by name.\n<b>/ckick, /cban</b>\nKick or ban a player by color.\n\n<b>/vip /moderator /admin</b>\nAdd a player as VIP, Moderator, or Admin.\n<b>/removevip, /removemoderator, /removeadmin</b>\nRemove VIP, Moderator, or Admin from a player.\n\n<b>/eg, /endgame</b>\nEnd the current game.\n<b>/em, /endmeeting</b>\nEnd the current meeting.\n<b>/s, /start</b>\nBegin the game starting countdown.\n\n<b>/t {template}</b>\nSend a template from AUR-DATA/templates.txt.\n\n<b>/col, /color, /colour</b>\nSet your color, can be used to bypass limits.",
+  "allCommandsFull": "<b>ALL COMMANDS:</b>\n\n<b>/help</b>\nShow this message.\n<b>/aur, /socials</b>\nSend Among Us Revamped social links.\n\n<b>/r, /gm</b>\nSend current mode description or ability list.\n<b>/r {ability}</b>\nSend specific ability info.\n<b>/l, /lastgame</b>\nSend last winner info.\n\n<b>/0kc, /0killcooldown</b>\nSend 0 Kill Cooldown mode description.\n<b>/sns, /shiftandseek</b>\nSend Shift and Seek mode description.\n<b>/sp, /speedrun</b>\nSend Speedrun mode description.\n<b>/hp, /hotpotato</b>\nSend Hot Potato mode description.\n\n/<b>kick, /ban</b>\nKick or ban a player by name.\n<b>/ckick, /cban</b>\nKick or ban a player by color.\n\n<b>/vip /moderator /admin</b>\nAdd a player as VIP, Moderator, or Admin.\n<b>/removevip, /removemoderator, /removeadmin</b>\nRemove VIP, Moderator, or Admin from a player.\n\n<b>/eg, /endgame</b>\nEnd the current game.\n<b>/em, /endmeeting</b>\nEnd the current meeting.\n<b>/s, /start</b>\nBegin the game starting countdown.\n\n<b>/t {template}</b>\nSend a template from AUR-DATA/templates.txt.\n\n<b>/col, /color, /colour</b>\nSet your color, can be used to bypass limits.",
 
   "translationReloaded": "Your file has successfully been reset.\nTo apply all changes, restart your game.",
 
@@ -270,6 +270,7 @@
   "snsDesc": "Send Shift and Seek gamemode Description.",
   "0kcDesc": "Send 0 Kill Cooldown gamemode Description.",
   "SrDesc": "Send Speedrun gamemode Description.",
+  "hpDesc": "Send Hot Potato gamemode Description.",
   "egDesc": "End the current game.",
   "emDesc": "End the current meeting.",
   "aurDesc": "Send Among Us Revamped social links.",
@@ -310,5 +311,22 @@
   "vipAndAbove": "<color=yellow>VIP</color> And Above",
   "moderatorAndAbove": "<color=purple>Moderator</color> And Above",
   "admin": "<color=red>Admin</color>",
-  "onlyYou": "Only You"
+  "onlyYou": "Only You",
+
+  "tabGroupHotPotato": "Hot Potato",
+  "potatoTimer": "Cook Time",
+  "potatoPassRadius": "Toss Range",
+  "potatoPassCooldown": "Cooldown After Tossing",
+  "potatoSpawnClearRadius": "Keep Vents Clear Of Spawn (range)",
+  "potatoHolderColor": "Potato Holder Color",
+  "safePlayerColor": "Safe Player Color",
+  "potatoBurnPassTarget": "Who Gets Potato After Burn",
+
+  "inviteAllFriends": "INVITE ALL",
+  "inviteAllFriendsButton": "Invite All Friends Button",
+  "inviteAllSending": "Sending lobby invites to {0} friends",
+  "inviteAllNoFriends": "No friends to invite",
+  "inviteAllNoLobby": "You must be in an online lobby to invite friends",
+  "inviteAllCooldown": "Invite all is on cooldown ({0}s)",
+  "inviteAllResult": "Invited {0}/{1} friends"
 }

--- a/Resources/Language/Italian.json
+++ b/Resources/Language/Italian.json
@@ -309,5 +309,12 @@
   "vipAndAbove": "<color=yellow>VIP</color> e superiori",
   "moderatorAndAbove": "<color=purple>Moderatori</color> e superiori",
   "admin": "<color=red>Admin</color>",
-  "onlyYou": "Solo tu"
+  "onlyYou": "Solo tu",
+  "inviteAllFriends": "INVITA TUTTI",
+  "inviteAllFriendsButton": "Pulsante Invita Tutti",
+  "inviteAllSending": "Invio inviti a {0} amici",
+  "inviteAllNoFriends": "Nessun amico da invitare",
+  "inviteAllNoLobby": "Devi essere in una lobby online per invitare gli amici",
+  "inviteAllCooldown": "Invita tutti è in ricarica ({0}s)",
+  "inviteAllResult": "Invitati {0}/{1} amici"
 }

--- a/Resources/Language/SimplifiedChinese.json
+++ b/Resources/Language/SimplifiedChinese.json
@@ -309,5 +309,12 @@
   "vipAndAbove": "<color=yellow>VIP</color> 及以上",
   "moderatorAndAbove": "<color=purple>管理员</color> 及以上",
   "admin": "<color=red>管理员</color>",
-  "onlyYou": "仅自己"
+  "onlyYou": "仅自己",
+  "inviteAllFriends": "邀请全部",
+  "inviteAllFriendsButton": "邀请所有好友按钮",
+  "inviteAllSending": "正在向 {0} 位好友发送房间邀请",
+  "inviteAllNoFriends": "没有可邀请的好友",
+  "inviteAllNoLobby": "必须在在线大厅中才能邀请好友",
+  "inviteAllCooldown": "邀请所有好友冷却中（{0} 秒）",
+  "inviteAllResult": "已邀请 {0}/{1} 位好友"
 }

--- a/Resources/Language/Spanish.json
+++ b/Resources/Language/Spanish.json
@@ -275,5 +275,12 @@
   "vipAndAbove": "<color=yellow>VIP</color> o superior",
   "moderatorAndAbove": "<color=purple>Moderador</color> o superior",
   "admin": "<color=red>Administrador</color>",
-  "onlyYou": "Solo tú"
+  "onlyYou": "Solo tú",
+  "inviteAllFriends": "INVITAR A TODOS",
+  "inviteAllFriendsButton": "Botón Invitar A Todos",
+  "inviteAllSending": "Enviando invitaciones a {0} amigos",
+  "inviteAllNoFriends": "No hay amigos a los que invitar",
+  "inviteAllNoLobby": "Debes estar en una sala en línea para invitar amigos",
+  "inviteAllCooldown": "Invitar a todos está en espera ({0}s)",
+  "inviteAllResult": "Invitados {0}/{1} amigos"
 }


### PR DESCRIPTION
Hot Potato: holder carries the potato and passes it by touching another player; the task bar acts as the countdown and the holder burns when it expires, last player standing wins. Configurable cook time, toss range, pass cooldown, holder/safe colors, and after-burn target (nearest/random). Commands: /hp, /hotpotato.

Invite All Friends: Shift+I in lobby (and client-options toggle) invites all Steam friends at once, with a cooldown. Strings for all 4 languages.

Bumped version to v1.8.5.